### PR TITLE
Fixed setup.py to install executable

### DIFF
--- a/malwarebazaar/__init__.py
+++ b/malwarebazaar/__init__.py
@@ -1,0 +1,1 @@
+import malwarebazaar

--- a/setup.py
+++ b/setup.py
@@ -2,10 +2,15 @@ from setuptools import setup
 
 setup(
     name='MalwareBazaar Command-Line Client',
-    version='1.0',
+    version='1.1',
     description='A command-line client to interact with the MalwareBazaar API',
     author='Lars Wallenborn',
     author_email='lars@wallenborn.net',
-    packages=['malware-bazaar-api-client'],
+    packages=['malwarebazaar'],
     install_requires=['requests', 'pyzipper'],
+    entry_points = {
+        'console_scripts': [
+             'baz = malwarebazaar.malwarebazaar:main',                  
+        ],              
+    },
 )


### PR DESCRIPTION
`setup.py` was throwing an error because the folder `malwarebazaar` may have originally been named `malware-bazaar-api-client` 

I also added an `entry_points` section to this script that will install the script. 